### PR TITLE
Fix shebang and make executable by default

### DIFF
--- a/nes_header_repair.py
+++ b/nes_header_repair.py
@@ -1,4 +1,4 @@
-#!/bin/python2
+#!/usr/bin/env python3
 
 # Header fixing script by Kitrinx
 


### PR DESCRIPTION
Using /usr/bin/env to launch python2 ensures compatibility across builds. Many distros don't have python2 available at /bin/python2.