### PR TITLE
fix ambiguous rom size notation

### DIFF
--- a/nes_header_repair.py
+++ b/nes_header_repair.py
@@ -48,7 +48,7 @@ def print_log(message, level):
 def make_rom_byte(romsize, divis, nes2):
 	rombyte = 0
 	# logic borrowed from NRS
-	if (romsize > 64 * 1024 * 1024 or romsize % divis != 0) and nes2: #exponent notation
+	if (romsize > 0xEFF * divis or romsize % divis != 0) and nes2: #exponent notation
 		multi = 1
 		if romsize % 3 == 0:
 			multi = 3
@@ -67,7 +67,7 @@ def make_rom_byte(romsize, divis, nes2):
 
 def make_rom_nibble(romsize, divis):
 	romnibble = 0
-	if romsize > 64 * 1024 * 1024 or romsize % divis != 0: #exponent notation
+	if romsize > 0xEFF * divis or romsize % divis != 0: #exponent notation
 		romnibble = 0xF
 	else:
 		romnibble = (int((romsize / divis)) & 0xF00) >> 8


### PR DESCRIPTION
The functions `make_rom_byte` and `make_rom_nibble` would use the old style ROM size notation with sizes up to 67,108,864.  However, for PRG-ROM and CHR-ROM, old style notation can only go up to 62,898,176 and 31,449,088 respectively, because any higher would put 0xF in the MSB which would signify exponent-multiplier notation.  This patch correctly caps the use of old style notation to values within the valid range.